### PR TITLE
Fix build: loosen yt-dlp to 2024 range (>=2024.7.7,<2025.0)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-telegram-bot==21.6
 faster-whisper==1.0.3
-yt-dlp==2024.06.28
+yt-dlp>=2024.7.7,<2025.0
 imageio-ffmpeg==0.4.9
 fastapi==0.115.0
 uvicorn==0.30.5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the version range for the yt-dlp package to allow for newer releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->